### PR TITLE
chore: update dependencies and refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "deno_emit"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ js-sys = { version = "0.3.55", optional = true }
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.68", features = ["preserve_order"] }
-wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"], optional = true }
+wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4.28", optional = true }
 
 [features]

--- a/_build.ts
+++ b/_build.ts
@@ -1,10 +1,8 @@
-#!/usr/bin/env -S deno run --unstable --allow-run --allow-read --allow-write --allow-env
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-import * as colors from "https://deno.land/std@0.111.0/fmt/colors.ts";
-import { copy } from "https://deno.land/std@0.111.0/fs/copy.ts";
-import { emptyDir } from "https://deno.land/std@0.111.0/fs/empty_dir.ts";
-import * as path from "https://deno.land/std@0.111.0/path/mod.ts";
+import * as colors from "https://deno.land/std@0.140.0/fmt/colors.ts";
+import { emptyDir } from "https://deno.land/std@0.140.0/fs/empty_dir.ts";
+import * as path from "https://deno.land/std@0.140.0/path/mod.ts";
 
 await Deno.permissions.request({ name: "env" });
 await Deno.permissions.request({ name: "run" });

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,21 @@
 {
+  "fmt": {
+    "files": {
+      "exclude": [
+        "static"
+      ]
+    }
+  },
+  "lint": {
+    "files": {
+      "exclude": [
+        "static/*.js",
+        "target"
+      ]
+    }
+  },
   "tasks": {
-    "test": "deno test --no-check --allow-read --allow-net --allow-env --allow-write",
-    "build": "deno run --unstable --allow-run --allow-read --allow-write --allow-env ./_build.ts"
+    "test": "deno test --allow-read --allow-net --allow-env --allow-write",
+    "build": "deno run --allow-run --allow-read --allow-write --allow-env ./_build.ts"
   }
 }

--- a/lib/deno_emit.generated.js
+++ b/lib/deno_emit.generated.js
@@ -141,7 +141,7 @@ function makeMutClosure(arg0, arg1, dtor, f) {
 }
 function __wbg_adapter_14(arg0, arg1, arg2) {
   wasm
-    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h28c77ba1afeb2b6a(
+    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__ha2dc225a6d0c8121(
       arg0,
       arg1,
       addHeapObject(arg2),
@@ -220,7 +220,7 @@ function handleError(f, args) {
   }
 }
 function __wbg_adapter_23(arg0, arg1, arg2, arg3) {
-  wasm.wasm_bindgen__convert__closures__invoke2_mut__he2cd558824276098(
+  wasm.wasm_bindgen__convert__closures__invoke2_mut__h231079c44e28ff87(
     arg0,
     arg1,
     addHeapObject(arg2),
@@ -315,8 +315,8 @@ const imports = {
     __wbindgen_throw: function (arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     },
-    __wbindgen_closure_wrapper3502: function (arg0, arg1, arg2) {
-      const ret = makeMutClosure(arg0, arg1, 240, __wbg_adapter_14);
+    __wbindgen_closure_wrapper3352: function (arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 189, __wbg_adapter_14);
       return addHeapObject(ret);
     },
   },

--- a/test.ts
+++ b/test.ts
@@ -3,14 +3,14 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.138.0/testing/asserts.ts";
+} from "https://deno.land/std@0.140.0/testing/asserts.ts";
 import { bundle, emit } from "./mod.ts";
 
 Deno.test({
   name: "bundle - basic",
   async fn() {
     const result = await bundle(
-      "https://deno.land/std@0.113.0/examples/chat/server.ts",
+      "https://deno.land/std@0.140.0/examples/chat/server.ts",
     );
     console.log(result);
     assert(result.code);
@@ -26,7 +26,7 @@ Deno.test({
     console.log(result);
     assertEquals(Object.keys(result).length, 1);
     const code = result[Object.keys(result)[0]];
-    assert(code)
+    assert(code);
     assertStringIncludes(code, "export default function hello()");
   },
 });


### PR DESCRIPTION
Fixes #8 
Closes #7

Plus adds some configuration so that `deno fmt` and `deno lint` work, and some other cleanup.