### PR TITLE
feat: Add CompilerOptions and minify options to bundle()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
  "deno_ast",
  "deno_graph",
  "futures",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "deno_ast",
  "futures",
  "lazy_static",
- "parking_lot 0.12.0",
+ "parking_lot",
  "regex",
  "ring",
  "serde",
@@ -544,15 +544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "is-macro"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,37 +742,12 @@ checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1180,7 +1146,7 @@ checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "phf_shared",
  "precomputed-hash",
  "serde",
@@ -1242,7 +1208,7 @@ dependencies = [
  "indexmap",
  "is-macro",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "petgraph",
  "radix_fmt",
  "relative-path",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -19,6 +19,6 @@
   },
   "tasks": {
     "test": "deno test --allow-read --allow-net --allow-env --allow-write",
-    "build": "deno run -A --unstable https://deno.land/x/wasmbuild@0.7.1/main.ts"
+    "build": "deno run -A --unstable https://deno.land/x/wasmbuild@0.8.3/main.ts"
   }
 }

--- a/lib/emit.generated.js
+++ b/lib/emit.generated.js
@@ -1,7 +1,7 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-// @generated file from build script, do not edit
+// @generated file from wasmbuild -- do not edit
 // deno-lint-ignore-file
-// source-hash: eaca51c4e0d425f2396de7263cfdb69efdee3351
+// deno-fmt-ignore-file
+// source-hash: 0a9f8673d401fe81a147bf87040db6ede2444c26
 let wasm;
 
 const heap = new Array(32).fill(undefined);
@@ -218,6 +218,7 @@ function isLikeNone(x) {
  * @param {string | undefined} maybe_bundle_type
  * @param {any} maybe_imports
  * @param {any} maybe_compiler_options
+ * @param {boolean} minify
  * @returns {Promise<any>}
  */
 export function bundle(
@@ -226,6 +227,7 @@ export function bundle(
   maybe_bundle_type,
   maybe_imports,
   maybe_compiler_options,
+  minify,
 ) {
   const ptr0 = passStringToWasm0(
     root,
@@ -249,6 +251,7 @@ export function bundle(
     len1,
     addHeapObject(maybe_imports),
     addHeapObject(maybe_compiler_options),
+    minify,
   );
   return takeObject(ret);
 }
@@ -256,10 +259,10 @@ export function bundle(
 /**
  * @param {string} root
  * @param {Function} load
- * @param {any} _options
+ * @param {any} options
  * @returns {Promise<any>}
  */
-export function transpile(root, load, _options) {
+export function transpile(root, load, options) {
   const ptr0 = passStringToWasm0(
     root,
     wasm.__wbindgen_malloc,
@@ -270,7 +273,7 @@ export function transpile(root, load, _options) {
     ptr0,
     len0,
     addHeapObject(load),
-    addHeapObject(_options),
+    addHeapObject(options),
   );
   return takeObject(ret);
 }
@@ -389,7 +392,7 @@ const imports = {
     __wbindgen_throw: function (arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     },
-    __wbindgen_closure_wrapper383: function (arg0, arg1, arg2) {
+    __wbindgen_closure_wrapper390: function (arg0, arg1, arg2) {
       const ret = makeMutClosure(arg0, arg1, 130, __wbg_adapter_16);
       return addHeapObject(ret);
     },
@@ -398,12 +401,21 @@ const imports = {
 
 const wasm_url = new URL("emit_bg.wasm", import.meta.url);
 
+/**
+ * Decompression callback
+ *
+ * @callback decompressCallback
+ * @param {Uint8Array} compressed
+ * @return {Uint8Array} decompressed
+ */
+
 /** Instantiates an instance of the Wasm module returning its functions.
  * @remarks It is safe to call this multiple times and once successfully
  * loaded it will always return a reference to the same object.
+ * @param {decompressCallback=} transform
  */
-export async function instantiate() {
-  return (await instantiateWithInstance()).exports;
+export async function instantiate(transform) {
+  return (await instantiateWithInstance(transform)).exports;
 }
 
 let instanceWithExports;
@@ -412,25 +424,26 @@ let lastLoadPromise;
 /** Instantiates an instance of the Wasm module along with its exports.
  * @remarks It is safe to call this multiple times and once successfully
  * loaded it will always return a reference to the same object.
+ * @param {decompressCallback=} transform
  * @returns {Promise<{
  *   instance: WebAssembly.Instance;
  *   exports: { bundle: typeof bundle; transpile: typeof transpile }
  * }>}
  */
-export function instantiateWithInstance() {
+export function instantiateWithInstance(transform) {
   if (instanceWithExports != null) {
     return Promise.resolve(instanceWithExports);
   }
   if (lastLoadPromise == null) {
     lastLoadPromise = (async () => {
       try {
-        const instance = (await instantiateModule()).instance;
+        const instance = (await instantiateModule(transform)).instance;
         wasm = instance.exports;
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
         instanceWithExports = {
           instance,
-          exports: { bundle, transpile },
+          exports: getWasmInstanceExports(),
         };
         return instanceWithExports;
       } finally {
@@ -441,12 +454,16 @@ export function instantiateWithInstance() {
   return lastLoadPromise;
 }
 
+function getWasmInstanceExports() {
+  return { bundle, transpile };
+}
+
 /** Gets if the Wasm module has been instantiated. */
 export function isInstantiated() {
   return instanceWithExports != null;
 }
 
-async function instantiateModule() {
+async function instantiateModule(transform) {
   switch (wasm_url.protocol) {
     case "file:": {
       if (typeof Deno !== "object") {
@@ -457,7 +474,10 @@ async function instantiateModule() {
         Deno.permissions.request({ name: "read", path: wasm_url });
       }
       const wasmCode = await Deno.readFile(wasm_url);
-      return WebAssembly.instantiate(wasmCode, imports);
+      return WebAssembly.instantiate(
+        !transform ? wasmCode : transform(wasmCode),
+        imports,
+      );
     }
     case "https:":
     case "http:": {
@@ -465,6 +485,10 @@ async function instantiateModule() {
         Deno.permissions.request({ name: "net", host: wasm_url.host });
       }
       const wasmResponse = await fetch(wasm_url);
+      if (transform) {
+        const wasmCode = new Uint8Array(await wasmResponse.arrayBuffer());
+        return WebAssembly.instantiate(transform(wasmCode), imports);
+      }
       if (
         wasmResponse.headers.get("content-type")?.toLowerCase().startsWith(
           "application/wasm",

--- a/mod.ts
+++ b/mod.ts
@@ -77,7 +77,6 @@ export interface EmitOptions {
   cacheRoot?: string;
   /** The setting to use when loading sources from the Deno cache. */
   cacheSetting?: CacheSetting;
-  compilerOptions?: CompilerOptions;
   //imports: Record<string, string[]>;
   /** Override the default loading mechanism with a custom loader. This can
    * provide a way to use "in-memory" resources instead of fetching them
@@ -85,7 +84,10 @@ export interface EmitOptions {
   load?: FetchCacher["load"];
   //type?: "module" | "classic";
   /** Minify the compiled code, default is false. */
-  minify?: boolean;
+  source_map?: boolean;
+  inline_sources?: boolean;
+  inline_source_map?: boolean;
+  emit_metadata?: boolean;
 }
 
 export interface CompilerOptions {

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -14,4 +14,4 @@ base64 = "0.13.0"
 deno_ast = { version = "0.16.0", features = ["bundler", "codegen", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "visit", "transpiling"] }
 deno_graph = "0.28.0"
 futures = "0.3.17"
-parking_lot = { version = "0.11.2" }
+parking_lot = { version = "0.12.1" }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -63,8 +63,7 @@ pub async fn transpile(
 
   for module in graph.modules() {
     if let Some(parsed_source) = &module.maybe_parsed_source {
-      let emit_options = &emitopts;
-      let transpiled_source = parsed_source.transpile(&emit_options)?;
+      let transpiled_source = parsed_source.transpile(&emitopts)?;
       map.insert(module.specifier.to_string(), transpiled_source.text);
       if let Some(source_map) = &transpiled_source.source_map {
         map.insert(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -35,13 +35,13 @@ pub async fn bundle(
     None,
   )
   .await;
-
   bundle_graph(&graph, bundle_options)
 }
 
 pub async fn transpile(
   root: ModuleSpecifier,
   loader: &mut dyn Loader,
+  emitopts: EmitOptions,
 ) -> Result<HashMap<String, String>> {
   let maybe_imports = None;
 
@@ -63,10 +63,8 @@ pub async fn transpile(
 
   for module in graph.modules() {
     if let Some(parsed_source) = &module.maybe_parsed_source {
-      // TODO: add emit options
-      let emit_options = Default::default();
+      let emit_options = &emitopts;
       let transpiled_source = parsed_source.transpile(&emit_options)?;
-
       map.insert(module.specifier.to_string(), transpiled_source.text);
       if let Some(source_map) = &transpiled_source.source_map {
         map.insert(

--- a/test.ts
+++ b/test.ts
@@ -3,8 +3,8 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.140.0/testing/asserts.ts";
-import { join } from "https://deno.land/std@0.140.0/path/mod.ts";
+} from "https://deno.land/std@0.146.0/testing/asserts.ts";
+import { join } from "https://deno.land/std@0.146.0/path/mod.ts";
 import { bundle, emit } from "./mod.ts";
 
 Deno.test({
@@ -23,7 +23,7 @@ Deno.test({
   async fn() {
     const result = await bundle(
       new URL(
-        "https://deno.land/std@0.140.0/examples/chat/server.ts",
+        "https://deno.land/std@0.146.0/examples/chat/server.ts",
       ),
     );
     console.log(result);


### PR DESCRIPTION
Partially fix #29 but is not fully complete.

It adds the ability to pass CompilerOptions object to Rust, so it is possible to toggle sourceMap/InlineSourceMap

```ts
BundleOptions {
...
  compilerOptions: {
        sourceMap: true,
        inlineSourceMap: true,
        ...
  },
..
}
```

I've also added `minify` option in BundleOptions interface to change the transpile output format, however this only works for bundle since the code uses `deno_graph::create_graph` from the `deno_ast` crates and it defaults to false..

I set this as draft pr because It may not be clean/full enough to be pushed to main.. just thought it would be a great start 
