### PR TITLE
fix: Escape reserved JSON characters before bundling into JS file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "base64 0.13.1",
  "deno_ast",
  "deno_graph",
+ "escape8259",
  "futures",
  "parking_lot 0.11.2",
 ]
@@ -332,6 +333,15 @@ dependencies = [
  "proc-macro2",
  "swc_macros_common",
  "syn",
+]
+
+[[package]]
+name = "escape8259"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4911e3666fcd7826997b4745c8224295a6f3072f1418c3067b97a67557ee"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1015,6 +1025,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"

--- a/lib/emit.generated.js
+++ b/lib/emit.generated.js
@@ -202,7 +202,7 @@ function makeMutClosure(arg0, arg1, dtor, f) {
 }
 function __wbg_adapter_16(arg0, arg1, arg2) {
   wasm
-    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hb50d428606e91cff(
+    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h140890174154bf02(
       arg0,
       arg1,
       addHeapObject(arg2),
@@ -283,7 +283,7 @@ function handleError(f, args) {
   }
 }
 function __wbg_adapter_25(arg0, arg1, arg2, arg3) {
-  wasm.wasm_bindgen__convert__closures__invoke2_mut__h05af4b22b5ef3ea9(
+  wasm.wasm_bindgen__convert__closures__invoke2_mut__hb779f41078b45a7b(
     arg0,
     arg1,
     addHeapObject(arg2),
@@ -389,7 +389,7 @@ const imports = {
     __wbindgen_throw: function (arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     },
-    __wbindgen_closure_wrapper368: function (arg0, arg1, arg2) {
+    __wbindgen_closure_wrapper359: function (arg0, arg1, arg2) {
       const ret = makeMutClosure(arg0, arg1, 129, __wbg_adapter_16);
       return addHeapObject(ret);
     },

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -13,5 +13,6 @@ anyhow = "1.0.44"
 base64 = "0.13.0"
 deno_ast = { version = "0.21.0", features = ["bundler", "codegen", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "visit", "transpiling"] }
 deno_graph = "0.39.0"
+escape8259 = "0.5.2"
 futures = "0.3.17"
 parking_lot = { version = "0.11.2" }

--- a/rs-lib/src/emit.rs
+++ b/rs-lib/src/emit.rs
@@ -24,6 +24,7 @@ use std::rc::Rc;
 
 use crate::bundle_hook::BundleHook;
 use crate::text::strip_bom;
+use crate::text::transform_json_source;
 
 const IGNORE_DIRECTIVES: &[&str] = &[
   "// deno-fmt-ignore-file",
@@ -242,10 +243,7 @@ fn transpile_module(
 ) -> Result<(Rc<swc::common::SourceFile>, swc::ast::Module)> {
   let source = strip_bom(source);
   let source = if media_type == MediaType::Json {
-    format!(
-      "export default JSON.parse(`{}`);",
-      source.replace("${", "\\${").replace('`', "\\`")
-    )
+    transform_json_source(source)
   } else {
     source.to_string()
   };

--- a/rs-lib/src/text.rs
+++ b/rs-lib/src/text.rs
@@ -11,6 +11,14 @@ pub fn strip_bom(text: &str) -> &str {
   }
 }
 
+pub fn transform_json_source(source: &str) -> String {
+  // Make sure to trim all redundant training newlines,
+  // and escape all reserved characters per JSON RFC,
+  // https://www.rfc-editor.org/rfc/rfc8259
+  let escaped = escape8259::escape(source.trim_end());
+  format!(r#"export default JSON.parse("{escaped}");"#)
+}
+
 #[cfg(test)]
 mod test {
   use super::*;
@@ -25,5 +33,29 @@ mod test {
   fn strip_bom_without_bom() {
     let text = "text";
     assert_eq!(strip_bom(text), "text");
+  }
+
+  #[test]
+  fn transform_json_source_simple() {
+    let text = r#"{"foo": "bar"}"#;
+    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar\"}");"#);
+  }
+
+  #[test]
+  fn transform_json_source_escape_newline() {
+    let text = r#"{"foo": "bar\nbaz"}"#;
+    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar\\nbaz\"}");"#);
+  }
+
+  #[test]
+  fn transform_json_source_escape_quotes() {
+    let text = r#"{"foo": "bar \"baz\" 'qux' `quaz`"}"#;
+    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar \\\"baz\\\" 'qux' `quaz`\"}");"#);
+  }
+
+  #[test]
+  fn transform_json_source_not_escape_string_interpolation() {
+    let text = r#"{"foo": "bar ${baz}"}"#;
+    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar ${baz}\"}");"#);
   }
 }

--- a/rs-lib/src/text.rs
+++ b/rs-lib/src/text.rs
@@ -38,24 +38,36 @@ mod test {
   #[test]
   fn transform_json_source_simple() {
     let text = r#"{"foo": "bar"}"#;
-    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar\"}");"#);
+    assert_eq!(
+      transform_json_source(text),
+      r#"export default JSON.parse("{\"foo\": \"bar\"}");"#
+    );
   }
 
   #[test]
   fn transform_json_source_escape_newline() {
     let text = r#"{"foo": "bar\nbaz"}"#;
-    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar\\nbaz\"}");"#);
+    assert_eq!(
+      transform_json_source(text),
+      r#"export default JSON.parse("{\"foo\": \"bar\\nbaz\"}");"#
+    );
   }
 
   #[test]
   fn transform_json_source_escape_quotes() {
     let text = r#"{"foo": "bar \"baz\" 'qux' `quaz`"}"#;
-    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar \\\"baz\\\" 'qux' `quaz`\"}");"#);
+    assert_eq!(
+      transform_json_source(text),
+      r#"export default JSON.parse("{\"foo\": \"bar \\\"baz\\\" 'qux' `quaz`\"}");"#
+    );
   }
 
   #[test]
   fn transform_json_source_not_escape_string_interpolation() {
     let text = r#"{"foo": "bar ${baz}"}"#;
-    assert_eq!(transform_json_source(text), r#"export default JSON.parse("{\"foo\": \"bar ${baz}\"}");"#);
+    assert_eq!(
+      transform_json_source(text),
+      r#"export default JSON.parse("{\"foo\": \"bar ${baz}\"}");"#
+    );
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -74,13 +74,17 @@ Deno.test({
   name: "bundle - json escapes",
   async fn() {
     const result = await bundle("./testdata/escape.ts");
-    const {code} = result;
+    const { code } = result;
     assert(code);
     // This is done on purpose, as `String.raw` still performs a string interpolation,
     // and we want a literal value ${jsInterpolation" as is, without any modifications.
     // We should not need to escape `$` nor `{` as they are both JSON-safe characters.
     const jsInterpolation = "${jsInterpolation}";
-    assertStringIncludes(code, String.raw`const __default = JSON.parse("{\"key\": \"a value with newline\\n, \\\"double quotes\\\", 'single quotes', and ${jsInterpolation}\"}");`);
+    assertStringIncludes(
+      code,
+      String
+        .raw`const __default = JSON.parse("{\n  \"key\": \"a value with newline\\n, \\\"double quotes\\\", 'single quotes', and ${jsInterpolation}\"\n}");`,
+    );
   },
 });
 

--- a/test.ts
+++ b/test.ts
@@ -71,6 +71,20 @@ Deno.test({
 });
 
 Deno.test({
+  name: "bundle - json escapes",
+  async fn() {
+    const result = await bundle("./testdata/escape.ts");
+    const {code} = result;
+    assert(code);
+    // This is done on purpose, as `String.raw` still performs a string interpolation,
+    // and we want a literal value ${jsInterpolation" as is, without any modifications.
+    // We should not need to escape `$` nor `{` as they are both JSON-safe characters.
+    const jsInterpolation = "${jsInterpolation}";
+    assertStringIncludes(code, String.raw`const __default = JSON.parse("{\"key\": \"a value with newline\\n, \\\"double quotes\\\", 'single quotes', and ${jsInterpolation}\"}");`);
+  },
+});
+
+Deno.test({
   name: "transpile - remote",
   async fn() {
     const result = await emit(

--- a/test.ts
+++ b/test.ts
@@ -76,6 +76,9 @@ Deno.test({
     const result = await bundle("./testdata/escape.ts");
     const { code } = result;
     assert(code);
+    const EOL = Deno?.build?.os === "windows"
+      ? String.raw`\r\n`
+      : String.raw`\n`;
     // This is done on purpose, as `String.raw` still performs a string interpolation,
     // and we want a literal value ${jsInterpolation" as is, without any modifications.
     // We should not need to escape `$` nor `{` as they are both JSON-safe characters.
@@ -83,7 +86,7 @@ Deno.test({
     assertStringIncludes(
       code,
       String
-        .raw`const __default = JSON.parse("{\n  \"key\": \"a value with newline\\n, \\\"double quotes\\\", 'single quotes', and ${jsInterpolation}\"\n}");`,
+        .raw`const __default = JSON.parse("{${EOL}  \"key\": \"a value with newline\\n, \\\"double quotes\\\", 'single quotes', and ${jsInterpolation}\"${EOL}}");`,
     );
   },
 });

--- a/testdata/escape.json
+++ b/testdata/escape.json
@@ -1,1 +1,3 @@
-{"key": "a value with newline\n, \"double quotes\", 'single quotes', and ${jsInterpolation}"}
+{
+  "key": "a value with newline\n, \"double quotes\", 'single quotes', and ${jsInterpolation}"
+}

--- a/testdata/escape.json
+++ b/testdata/escape.json
@@ -1,0 +1,1 @@
+{"key": "a value with newline\n, \"double quotes\", 'single quotes', and ${jsInterpolation}"}

--- a/testdata/escape.ts
+++ b/testdata/escape.ts
@@ -1,0 +1,5 @@
+import j from './escape.json' assert { type: 'json' }
+
+export default function payload(): string {
+  return JSON.stringify(j);
+}

--- a/testdata/escape.ts
+++ b/testdata/escape.ts
@@ -1,4 +1,4 @@
-import j from './escape.json' assert { type: 'json' }
+import j from "./escape.json" assert { type: "json" };
 
 export default function payload(): string {
   return JSON.stringify(j);


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/14012 and removes unnecessary line-ending from the processed output, as before the trimming, it always ended up looking like this:

```js
__default = JSON.parse(`{"foo": "bar"}
`);
```

Escaping is done using https://docs.rs/escape8259/ and verified correctness with the https://www.rfc-editor.org/rfc/rfc8259 itself. I didn't see a point vendoring such a small library, but if necessary, we can do that.