### PR TITLE
Fix: Update mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -157,9 +157,9 @@ export async function bundle(
   return jsBundle(
     root.toString(),
     bundleLoad,
+    "module",
     JSON.stringify(imports),
-    undefined,
-    undefined,
+    JSON.stringify({})
   );
 }
 


### PR DESCRIPTION
The signature of bundle from the bindings doesn't match the signature of bundle exported for mod.ts, so this change updates it so that at least the right params are being passed.

(note that this module may not work even with the params/arity correction)