### PR TITLE
feat: implement compiler options

### DIFF
--- a/lib/emit.generated.js
+++ b/lib/emit.generated.js
@@ -202,7 +202,7 @@ function makeMutClosure(arg0, arg1, dtor, f) {
 }
 function __wbg_adapter_16(arg0, arg1, arg2) {
   wasm
-    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hc399077d245373c2(
+    ._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h2eb231fdb129de9b(
       arg0,
       arg1,
       addHeapObject(arg2),
@@ -283,7 +283,7 @@ function handleError(f, args) {
   }
 }
 function __wbg_adapter_25(arg0, arg1, arg2, arg3) {
-  wasm.wasm_bindgen__convert__closures__invoke2_mut__h3cf9829b75bbfd88(
+  wasm.wasm_bindgen__convert__closures__invoke2_mut__h0edd3e8b1a7686ec(
     arg0,
     arg1,
     addHeapObject(arg2),
@@ -389,8 +389,8 @@ const imports = {
     __wbindgen_throw: function (arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     },
-    __wbindgen_closure_wrapper422: function (arg0, arg1, arg2) {
-      const ret = makeMutClosure(arg0, arg1, 144, __wbg_adapter_16);
+    __wbindgen_closure_wrapper423: function (arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 138, __wbg_adapter_16);
       return addHeapObject(ret);
     },
   },

--- a/mod.ts
+++ b/mod.ts
@@ -146,6 +146,8 @@ export async function bundle(
     cacheSetting,
     cacheRoot,
     allowRemote,
+    type,
+    compilerOptions,
   } = options;
   let bundleLoad = load;
   if (!bundleLoad) {
@@ -154,13 +156,17 @@ export async function bundle(
   }
   root = root instanceof URL ? root : toFileUrl(resolve(root));
   const { bundle: jsBundle } = await instantiate();
-  return jsBundle(
+  const result = await jsBundle(
     root.toString(),
     bundleLoad,
-    JSON.stringify(imports),
-    undefined,
-    undefined,
+    type,
+    imports,
+    compilerOptions,
   );
+  return {
+    code: result.code,
+    map: result.maybe_map ?? undefined,
+  };
 }
 
 /** Transpile TypeScript (or JavaScript) into JavaScript, returning a promise

--- a/tests/__snapshots__/bundle/inline_source_maps_are_enabled_by_default.js
+++ b/tests/__snapshots__/bundle/inline_source_maps_are_enabled_by_default.js
@@ -1,0 +1,5 @@
+function hello() {
+    return "Hello there!";
+}
+export { hello as default };
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpbGU6Ly8vdGVzdGRhdGEvbW9kLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIGhlbGxvKCk6IHN0cmluZyB7XG4gIHJldHVybiBcIkhlbGxvIHRoZXJlIVwiO1xufVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFlLFNBQVMsUUFBZ0I7SUFDdEMsT0FBTztBQUNUO0FBRkEsNEJBRUMifQ==

--- a/tests/__snapshots__/bundle/setting_inlinesourcemap_does_not_produce_any_source_maps.js
+++ b/tests/__snapshots__/bundle/setting_inlinesourcemap_does_not_produce_any_source_maps.js
@@ -1,0 +1,4 @@
+function hello() {
+    return "Hello there!";
+}
+export { hello as default };

--- a/tests/__snapshots__/bundle/setting_inlinesourcemap_to_true_produces_inline_source_maps.js
+++ b/tests/__snapshots__/bundle/setting_inlinesourcemap_to_true_produces_inline_source_maps.js
@@ -1,0 +1,5 @@
+function hello() {
+    return "Hello there!";
+}
+export { hello as default };
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpbGU6Ly8vdGVzdGRhdGEvbW9kLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIGhlbGxvKCk6IHN0cmluZyB7XG4gIHJldHVybiBcIkhlbGxvIHRoZXJlIVwiO1xufVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFlLFNBQVMsUUFBZ0I7SUFDdEMsT0FBTztBQUNUO0FBRkEsNEJBRUMifQ==

--- a/tests/__snapshots__/bundle/setting_sourcemap_to_true_and_inlinesourcemap_to_false_produces_external_source_maps.js
+++ b/tests/__snapshots__/bundle/setting_sourcemap_to_true_and_inlinesourcemap_to_false_produces_external_source_maps.js
@@ -1,0 +1,4 @@
+function hello() {
+    return "Hello there!";
+}
+export { hello as default };

--- a/tests/__snapshots__/bundle/setting_sourcemap_to_true_and_inlinesourcemap_to_false_produces_external_source_maps.js.map
+++ b/tests/__snapshots__/bundle/setting_sourcemap_to_true_and_inlinesourcemap_to_false_produces_external_source_maps.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["file:///testdata/mod.ts"],"sourcesContent":["export default function hello(): string {\n  return \"Hello there!\";\n}\n"],"names":[],"mappings":"AAAe,SAAS,QAAgB;IACtC,OAAO;AACT;AAFA,4BAEC"}

--- a/tests/__snapshots__/bundle/setting_sourcemap_to_true_is_not_enough_to_produce_external_source_maps_as_inline_takes_precedence.js
+++ b/tests/__snapshots__/bundle/setting_sourcemap_to_true_is_not_enough_to_produce_external_source_maps_as_inline_takes_precedence.js
@@ -1,0 +1,4 @@
+function hello() {
+    return "Hello there!";
+}
+export { hello as default };


### PR DESCRIPTION
Since the initial release, the bundle type, the compiler options and the imports were not properly forwarded from JS to Rust.

We now forward them, and added some tests to verify this behavior.

Closes https://github.com/denoland/deno_emit/issues/83, https://github.com/denoland/deno_emit/issues/69, https://github.com/denoland/deno_emit/issues/29.