### PR TITLE
feat: rename emit to transpile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ transpiled fashion. An example of taking some TypeScript and transpiling to
 JavaScript:
 
 ```ts
-import { emit } from "https://deno.land/x/emit/mod.ts";
+import { transpile } from "https://deno.land/x/emit/mod.ts";
 
 const url = new URL("./testdata/mod.ts", import.meta.url);
-const result = await emit(url);
+const result = await transpile(url);
 
 const code = result[url.href];
 console.log(code.includes("export default function hello()"));

--- a/mod.ts
+++ b/mod.ts
@@ -8,10 +8,10 @@
  * ### Example - Transpiling
  *
  * ```ts
- * import { emit } from "https://deno.land/x/emit/mod.ts";
+ * import { transpile } from "https://deno.land/x/emit/mod.ts";
  *
  * const url = new URL("./testdata/mod.ts", import.meta.url);
- * const result = await emit(url.href);
+ * const result = await transpile(url.href);
  *
  * const { code } = result;
  * console.log(code.includes("export default function hello()"));
@@ -67,8 +67,8 @@ export interface BundleOptions {
   type?: "module" | "classic";
 }
 
-/** Options which can be set when using the {@linkcode emit} function. */
-export interface EmitOptions {
+/** Options which can be set when using the {@linkcode transpile} function. */
+export interface TranspileOptions {
   /** Allow remote modules to be loaded or read from the cache. */
   allowRemote?: boolean;
   /** The cache root to use, overriding the default inferred `DENO_DIR`. */
@@ -172,17 +172,17 @@ export async function bundle(
  *          where the key is the emitted files name and the value is the
  *          source for the file.
  */
-export async function emit(
+export async function transpile(
   root: string | URL,
-  options: EmitOptions = {},
+  options: TranspileOptions = {},
 ): Promise<Record<string, string>> {
   root = root instanceof URL ? root : toFileUrl(resolve(root));
   const { cacheSetting, cacheRoot, allowRemote, load } = options;
-  let emitLoad = load;
-  if (!emitLoad) {
+  let transpileLoad = load;
+  if (!transpileLoad) {
     const cache = createCache({ root: cacheRoot, cacheSetting, allowRemote });
-    emitLoad = cache.load;
+    transpileLoad = cache.load;
   }
   const { transpile } = await instantiate();
-  return transpile(root.toString(), emitLoad, undefined);
+  return transpile(root.toString(), transpileLoad, undefined);
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -15,7 +15,12 @@ import {
   buildMessage,
   diffstr,
 } from "https://deno.land/std@0.182.0/testing/_diff.ts";
-import { bundle, type BundleOptions, emit, type EmitOptions } from "../mod.ts";
+import {
+  bundle,
+  type BundleOptions,
+  transpile,
+  type TranspileOptions,
+} from "../mod.ts";
 import * as base64Url from "https://deno.land/std@0.182.0/encoding/base64url.ts";
 import * as base64 from "https://deno.land/std@0.182.0/encoding/base64.ts";
 
@@ -28,7 +33,7 @@ const inlineSourceMapRegex =
 // Tracks which snapshots are involved in order to identify conflicts.
 const tracker: Set<string> = new Set();
 
-type TranspileResult = Awaited<ReturnType<typeof emit>>;
+type TranspileResult = Awaited<ReturnType<typeof transpile>>;
 interface TestTranspileOutput {
   result: TranspileResult;
   modulesPaths: Record<string, string>;
@@ -42,9 +47,9 @@ interface TestBundleOutput {
 }
 
 /**
- * Calls `emit` with the provided parameters and checks that the output is
+ * Calls `transpile` with the provided parameters and checks that the output is
  * consistent with the snapshots.
- * Each module in the record returned by `emit` is stored as its own file.
+ * Each module in the record returned by `transpile` is stored as its own file.
  * In order to avoid special characters, the file name is a hash of the module's
  * URL. The mapping between the hashes and the URLs is stored alongside the
  * modules.
@@ -56,14 +61,14 @@ interface TestBundleOutput {
  */
 export function testTranspile(
   root: string | URL,
-  options?: EmitOptions,
+  options?: TranspileOptions,
   more?: (
     output: TestTranspileOutput,
     t: Deno.TestContext,
   ) => void | Promise<void>,
 ) {
   return async function (t: Deno.TestContext): Promise<void> {
-    const result = fixTranspileResult(await emit(root, options));
+    const result = fixTranspileResult(await transpile(root, options));
 
     const testDir = resolve(getSnapshotDir(t), getTestName(t));
 


### PR DESCRIPTION
That seems like a more consistent naming. It also disambiguates between `deno_emit` as a whole and `emit()` itself, which is only half of `deno_emit`.

Closes #16.