### PR TITLE
feat: add minify configuration to BundleOptions

### DIFF
--- a/js/mod.ts
+++ b/js/mod.ts
@@ -77,6 +77,8 @@ export interface BundleOptions {
    * provide a way to use "in-memory" resources instead of fetching them
    * remotely. */
   load?: FetchCacher["load"];
+  /** Minify compiled code, default false. */
+  minify?: boolean;
   /** Should the emitted bundle be an ES module or an IIFE script. The default
    * is `"module"` to output a ESM module. */
   type?: "module" | "classic";
@@ -166,6 +168,7 @@ export async function bundle(
     compilerOptions,
     importMap,
     load,
+    minify,
     type,
   } = options;
 
@@ -183,6 +186,7 @@ export async function bundle(
     type,
     processImportMapInput(importMap),
     compilerOptions,
+    minify ?? false,
   );
   return {
     code: result.code,

--- a/rs-lib/src/emit.rs
+++ b/rs-lib/src/emit.rs
@@ -53,6 +53,7 @@ pub struct BundleOptions {
   pub bundle_type: BundleType,
   pub emit_options: EmitOptions,
   pub emit_ignore_directives: bool,
+  pub minify: bool,
 }
 
 pub struct TranspileOptions {
@@ -203,7 +204,7 @@ pub fn bundle_graph(
     let mut srcmap = Vec::new();
     {
       let cfg = swc::codegen::Config {
-        minify: false,
+        minify: options.minify,
         ascii_only: false,
         target: deno_ast::ES_VERSION,
         omit_last_semi: false,
@@ -401,6 +402,7 @@ export const b = "b";
         bundle_type: crate::BundleType::Module,
         emit_ignore_directives: false,
         emit_options: Default::default(),
+        minify: false,
       },
     )
     .unwrap();
@@ -411,6 +413,25 @@ const b = "b";
 export { b as b };
 "#,
       output.code.split_once("//# sourceMappingURL").unwrap().0
+    );
+
+    let minified_output = bundle_graph(
+      &graph,
+      BundleOptions {
+        bundle_type: crate::BundleType::Module,
+        emit_ignore_directives: false,
+        emit_options: Default::default(),
+        minify: true,
+      },
+    )
+    .unwrap();
+    assert_eq!(
+      r#"import"https://example.com/external.ts";const b="b";export{b as b};"#,
+      minified_output
+        .code
+        .split_once("//# sourceMappingURL")
+        .unwrap()
+        .0
     );
   }
 
@@ -434,6 +455,7 @@ export { b as b };
         bundle_type: crate::BundleType::Module,
         emit_ignore_directives: false,
         emit_options: Default::default(),
+        minify: false,
       },
     )
     .unwrap();

--- a/tests/__snapshots__/bundle/minified_json_import.js
+++ b/tests/__snapshots__/bundle/minified_json_import.js
@@ -1,0 +1,1 @@
+const __default=JSON.parse('{\n  "$var": { "a": 123, "b": [1, 2, 3], "c": null },\n  "with space": "invalid variable name",\n  "function": "reserved word"\n}');console.log(__default);

--- a/tests/bundle_test.ts
+++ b/tests/bundle_test.ts
@@ -43,6 +43,18 @@ Deno.test({
 });
 
 Deno.test({
+    name: "minified json import",
+    fn: testBundle(
+        resolveFixture("json_import.ts"),
+        { minify: true },
+        async ({ outputFileUrl }) => {
+            const output = await runModule(outputFileUrl);
+            assertStringIncludes(output, "with space");
+        },
+    ),
+});
+
+Deno.test({
   name: "circular",
   fn: testBundle(
     resolveFixture("circular1.ts"),

--- a/tests/bundle_test.ts
+++ b/tests/bundle_test.ts
@@ -43,15 +43,15 @@ Deno.test({
 });
 
 Deno.test({
-    name: "minified json import",
-    fn: testBundle(
-        resolveFixture("json_import.ts"),
-        { minify: true },
-        async ({ outputFileUrl }) => {
-            const output = await runModule(outputFileUrl);
-            assertStringIncludes(output, "with space");
-        },
-    ),
+  name: "minified json import",
+  fn: testBundle(
+    resolveFixture("json_import.ts"),
+    { minify: true },
+    async ({ outputFileUrl }) => {
+      const output = await runModule(outputFileUrl);
+      assertStringIncludes(output, "with space");
+    },
+  ),
 });
 
 Deno.test({

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -167,6 +167,7 @@ pub async fn bundle(
   maybe_bundle_type: Option<String>,
   maybe_import_map: JsValue,
   maybe_compiler_options: JsValue,
+  minify: bool,
 ) -> Result<JsValue, JsValue> {
   // todo(dsherret): eliminate all the duplicate `.map_err`s
   let compiler_options: CompilerOptions = serde_wasm_bindgen::from_value::<
@@ -206,7 +207,7 @@ pub async fn bundle(
       bundle_type,
       emit_options,
       emit_ignore_directives: false,
-      minify: false,
+      minify,
     },
   )
   .await

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -206,6 +206,7 @@ pub async fn bundle(
       bundle_type,
       emit_options,
       emit_ignore_directives: false,
+      minify: false,
     },
   )
   .await


### PR DESCRIPTION
This PR adds a `minify` option to `BundleOptions` and passes the option through to `swc::codegen::Config`.

Partially based on https://github.com/denoland/deno_emit/pull/63

Thanks!