### PR TITLE
chore: fix import map document url

### DIFF
--- a/js/mod.ts
+++ b/js/mod.ts
@@ -51,7 +51,7 @@ export interface BundleEmit {
   map?: string;
 }
 
-/** An [import-map](https://deno.land/manual/linking_to_external_code/import_maps#import-maps) */
+/** An [import-map](https://docs.deno.com/runtime/manual/basics/import_maps) */
 export interface ImportMap {
   /** Base URL to resolve import map specifiers. It Is always treated as a
    * directory. Defaults to the file URL of `Deno.cwd()`. */
@@ -71,7 +71,7 @@ export interface BundleOptions {
   cacheSetting?: CacheSetting;
   /** Compiler options which can be set when bundling. */
   compilerOptions?: CompilerOptions;
-  /** An [import-map](https://deno.land/manual/linking_to_external_code/import_maps#import-maps)
+  /** An [import-map](https://docs.deno.com/runtime/manual/basics/import_maps)
    * which will be applied to the imports, or the URL of an import map, or the
    * path to an import map */
   importMap?: ImportMap | URL | string;
@@ -96,7 +96,7 @@ export interface TranspileOptions {
   cacheSetting?: CacheSetting;
   /** Compiler options which can be set when transpiling. */
   compilerOptions?: CompilerOptions;
-  /** An [import-map](https://deno.land/manual/linking_to_external_code/import_maps#import-maps)
+  /** An [import-map](https://docs.deno.com/runtime/manual/basics/import_maps)
    * which will be applied to the imports, or the URL of an import map, or the
    * path to an import map */
   importMap?: ImportMap | URL | string;


### PR DESCRIPTION
https://deno.land/manual/linking_to_external_code/import_maps#import-maps
(redirect to https://docs.deno.com/runtime/manual/linking_to_external_code/import_maps#import-maps) in the URL contained in the document comment of importMap is NOT FOUND

Changed to the supposedly expected new document URL https://docs.deno.com/runtime/manual/basics/import_maps

![image](https://github.com/denoland/deno_emit/assets/16481886/c19ef7ff-2739-46fb-9b8d-35edbc4c8692)
